### PR TITLE
Async.CancellationToken: Disallow {reason}

### DIFF
--- a/autoload/vital/__vital__/Async/CancellationTokenSource.vim
+++ b/autoload/vital/__vital__/Async/CancellationTokenSource.vim
@@ -41,13 +41,12 @@ function! s:new(...) abort
   return source
 endfunction
 
-function! s:_cancel(...) abort dict
-  if self._state !=# s:CancellationToken.STATE_OPEN
+function! s:_cancel() abort dict
+  if self._state isnot# s:CancellationToken.STATE_OPEN
     return
   endif
 
-  let reason = a:0 ? a:1 : 'Operation has cancelled'
-  let self._state = s:CancellationToken.cancel_error(reason)
+  let self._state = s:CancellationToken.STATE_REQUESTED
   call s:_unlink(self)
 
   let registrations = filter(
@@ -57,7 +56,7 @@ function! s:_cancel(...) abort dict
   let self._registrations = []
   for registration in registrations
     try
-      call registration._target(reason)
+      call registration._target()
     catch
       let exception = v:exception
       call timer_start(0, { -> s:_throw(exception) })
@@ -66,7 +65,7 @@ function! s:_cancel(...) abort dict
 endfunction
 
 function! s:_close() abort dict
-  if self._state !=# s:CancellationToken.STATE_OPEN
+  if self._state isnot# s:CancellationToken.STATE_OPEN
     return
   endif
 
@@ -82,5 +81,5 @@ function! s:_unlink(source) abort
 endfunction
 
 function! s:_throw(exception) abort
-  echoerr a:exception
+  throw a:exception
 endfunction

--- a/doc/Vital/Async/CancellationToken.txt
+++ b/doc/Vital/Async/CancellationToken.txt
@@ -62,9 +62,7 @@ cancelled (|Vital.Async.CancellationToken.none|).
 	  " Define cancellation callback
 	  function! s:on_cancel(reason) abort closure
 	    call ns.job.stop()
-	    call a:reject({
-	        \ 'exception': s:CancellationToken.cancel_error(a:reason),
-	        \})
+	    call a:reject(s:CancellationToken.CancellationError)
 	  endfunction
 	
 	  " Register cancellation callback
@@ -108,6 +106,9 @@ CONSTANT			*Vital.Async.CancellationToken-constant*
 .canceled
 	A token that is already been canceled.
 
+			*Vital.Async.CancellationToken.CancellationError*
+.CancellationError
+	An error string thrown when a token has cancelled.
 
 -----------------------------------------------------------------------------
 FUNCTION			*Vital.Async.CancellationToken-function*
@@ -118,10 +119,6 @@ FUNCTION			*Vital.Async.CancellationToken-function*
 
 	See also:
 	|Vital.Async.CancellationTokenSource.new()|
-
-			*Vital.Async.CancellationToken.cancel_error()*
-.cancel_error({reason})
-	Create a cancel error message with {reason}.
 
 -----------------------------------------------------------------------------
 INSTANCE			*Vital.Async.CancellationToken-instance*

--- a/doc/Vital/Async/CancellationTokenSource.txt
+++ b/doc/Vital/Async/CancellationTokenSource.txt
@@ -47,7 +47,7 @@ longer than 1000ms, an internal process (curl) will be killed by cancellation.
 	        \.then({ r -> execute('echomsg "OK: " . string(r)', '') })
 	        \.catch({ r -> execute('echomsg "Fail: " . string(r)', '') })
 	
-	  call timer_start(1000, { -> source.cancel('Timeout') })
+	  call timer_start(1000, { -> source.cancel() })
 	endfunction
 	call s:test()
 <
@@ -75,7 +75,7 @@ FUNCTION		*Vital.Async.CancellationTokenSource-function*
 INSTANCE		*Vital.Async.CancellationTokenSource-instance*
 
 	*Vital.Async.CancellationTokenSource-ins.cancel()*
-.cancel([{reason}])
+.cancel()
 	Requests cancellation. All cancellation callbacks in all linked
 	tokens will be called.
 	When any exceptions are occurred in cancellation callback, the

--- a/test/Async/CancellationToken.vimspec
+++ b/test/Async/CancellationToken.vimspec
@@ -17,13 +17,6 @@ Describe Async.CancellationToken
     End
   End
 
-  Describe .cancel_error({reason})
-    It returns a cancel error message with a given {reason}
-      let m = CancellationToken.cancel_error('Timeout')
-      Assert Equals(m, 'vital: Async.CancellationToken: CancelError: Timeout')
-    End
-  End
-
   Context a token instance
     Before
       let source = {
@@ -77,7 +70,7 @@ Describe Async.CancellationToken
 
       It throws a cancel error when cancellation has already been requested
         let source._state = CancellationToken.STATE_REQUESTED
-        Throws /CancelError/ token.throw_if_cancellation_requested()
+        Throws /CancelledError/ token.throw_if_cancellation_requested()
       End
     End
 


### PR DESCRIPTION
A {reason} message of 'cancel()' method was not useful and made things
a bit complecated so I decided to follow TC39 a bit more properly.