### PR TITLE
System.Job: Compatibility of .pid() for Neovim v0.4.0-dev

### DIFF
--- a/autoload/vital/__vital__/System/Job/Neovim.vim
+++ b/autoload/vital/__vital__/System/Job/Neovim.vim
@@ -21,6 +21,7 @@ function! s:start(args, options) abort
     let job_options.on_exit = funcref('s:_on_exit_raw', [job])
   endif
   let job.__job = jobstart(a:args, job_options)
+  let job.__pid = s:_jobpid_safe(job.__job)
   let job.__exitval = v:null
   let job.args = a:args
   return job
@@ -63,6 +64,17 @@ function! s:_on_exit_raw(job, job_id, exitval, event) abort
   let a:job.__exitval = a:exitval
 endfunction
 
+function! s:_jobpid_safe(job) abort
+  try
+    return jobpid(a:job)
+  catch /^Vim\%((\a\+)\)\=:E900/
+    " NOTE:
+    " Vim does not raise exception even the job has already closed so fail
+    " silently for 'E900: Invalid job id' exception
+    return 0
+  endtry
+endfunction
+
 " Instance -------------------------------------------------------------------
 function! s:_job_id() abort dict
   if &verbose
@@ -74,7 +86,7 @@ function! s:_job_id() abort dict
 endfunction
 
 function! s:_job_pid() abort dict
-  return jobpid(self.__job)
+  return self.__pid
 endfunction
 
 function! s:_job_status() abort dict

--- a/doc/Vital/System/Job.txt
+++ b/doc/Vital/System/Job.txt
@@ -194,6 +194,8 @@ INSTANCE					*Vital.System.Job-instance*
 					*Vital.System.Job-instance.pid()*
 pid()
 	Return a process id.
+	It keeps returning a same process id even when the process has
+	terminated.
 
 					*Vital.System.Job-instance.status()*
 status()

--- a/test/System/Job.vimspec
+++ b/test/System/Job.vimspec
@@ -376,6 +376,15 @@ Describe System.Job
         call job1.wait(TIMEOUT)
         call job2.wait(TIMEOUT)
       End
+
+      It keeps equal PID even when a process exit
+        let job = Job.start(Args('never.py'), options)
+        let pid = job.pid()
+        call job.stop()
+        call job.wait(TIMEOUT)
+        Assert IsNumber(job.pid())
+        Assert Equals(job.pid(), pid)
+      End
     End
 
     Describe .status()


### PR DESCRIPTION
Vim keeps the process id even for the process has terminated.
So mimic that feature in Neovim v0.4.0-dev as well.

ref: https://github.com/lambdalisue/gina.vim/issues/216