### PR TITLE
Avoid E118 error on trash()

### DIFF
--- a/autoload/vital/__vital__/Async/File.vim
+++ b/autoload/vital/__vital__/Async/File.vim
@@ -272,7 +272,7 @@ else
   endfunction
   " freedesktop
   " https://www.freedesktop.org/wiki/Specifications/trash-spec/
-  function! s:trash(path) abort
+  function! s:trash(path, ...) abort
     throw 'vital: Async.File: trash(): Not supported platform.'
   endfunction
 endif


### PR DESCRIPTION
Below error occured using trash on an unsupported platform
because of function type mismatch.

```
E118: Too many arguments for function: <SNR>144_trash
```

I found this error when using https://github.com/lambdalisue/fern.vim .
So please update fern.vim also if you can.