### PR TITLE
System.Job: Fix help tag for `|Vital.System.Job-promise|`

### DIFF
--- a/doc/Vital/System/Job.txt
+++ b/doc/Vital/System/Job.txt
@@ -111,7 +111,7 @@ from "exit_cb" in Vim 8 while this library waits "close_cb" when "on_stdout"
 and/or "on_stderr" are defined.
 
 -----------------------------------------------------------------------------
-PROMISE      					|Vital.System.Job-promise|
+PROMISE      					*Vital.System.Job-promise*
 
 The following example code uses |Vital.Async.Promise| to wrap process.
 Not like examples in Async.Promise, the following works on both Vim and


### PR DESCRIPTION
This fixes a help tag in `Job.txt`.