### PR TITLE
Fix nmap list for neovim maps with description

### DIFF
--- a/autoload/vital/__vital__/App/Action.vim
+++ b/autoload/vital/__vital__/App/Action.vim
@@ -99,6 +99,7 @@ function! s:list(...) abort
   let conceal = a:0 ? a:1 : v:true
   let l:Sort = { a, b -> s:_compare(a[1], b[1]) }
   let rs = split(execute('nmap'), '\n')
+  call filter(rs, {_, v -> match(v, '^n') != -1})
   call map(rs, { _, v -> v[3:] })
   call map(rs, { _, v -> matchlist(v, '^\([^ ]\+\)\s*\*\?@\?\(.*\)$')[1:2] })
 


### PR DESCRIPTION
When using the latest neovim with keymap API [1, 2], we can optionally set the description for keymaps as:

```
vim.keymap.set("n", "<C-W>Q", "<Cmd>tabclose<CR>", { desc = "Close tab" })
```

This interferes with fern, when hitting `?` key or executing `help` action, it iterates over all the mappings, using `execute('nmap')`, but using mappings with desc gives output like:
```
n  <C-W>Q      * <Cmd>tabclose<CR>
                 Close tab
```
where the second line is a description. This PR filters those lines so we don't get any other errors when processing the lines later on.

[1] https://neovim.io/doc/user/lua.html#vim.keymap.set()
[2] https://neovim.io/doc/user/api.html#nvim_set_keymap()