### PR TITLE
Skip floating window on WindowLocator

### DIFF
--- a/autoload/vital/__vital__/App/WindowLocator.vim
+++ b/autoload/vital/__vital__/App/WindowLocator.vim
@@ -7,6 +7,11 @@ let s:conditions = [
       \ { wi -> !getbufvar(wi.bufnr, '&previewwindow', 0) },
       \]
 
+" Add condition to check if the window is floating
+if exists('*nvim_win_get_config')
+  call add(s:conditions, { wi -> nvim_win_get_config(wi.winid).relative !=# '' })
+endif
+
 function! s:score(winnr) abort
   let winid = win_getid(a:winnr)
   let wininfo = getwininfo(winid)


### PR DESCRIPTION
Neovim's floating window should be skipped.

### See also

https://github.com/lambdalisue/fern.vim/issues/422