### PR TITLE
Use `noautocmd` to avoid `WinEnter`, `WinLeave` events

### DIFF
--- a/autoload/vital/__vital__/Vim/Window/Cursor.vim
+++ b/autoload/vital/__vital__/Vim/Window/Cursor.vim
@@ -6,10 +6,10 @@ if !exists('*nvim_win_get_cursor')
     else
       let winid_saved = win_getid()
       try
-        call win_gotoid(a:winid)
+        noautocmd call win_gotoid(a:winid)
         return s:get_cursor(a:winid)
       finally
-        call win_gotoid(winid_saved)
+        noautocmd call win_gotoid(winid_saved)
       endtry
     endif
   endfunction
@@ -27,10 +27,10 @@ if !exists('*nvim_win_set_cursor')
     else
       let winid_saved = win_getid()
       try
-        call win_gotoid(a:winid)
+        noautocmd call win_gotoid(a:winid)
         call s:set_cursor(a:winid, a:pos)
       finally
-        call win_gotoid(winid_saved)
+        noautocmd call win_gotoid(winid_saved)
       endtry
     endif
   endfunction


### PR DESCRIPTION
It appears that the `get_cursor` and `set_cursor` functions are not consistently implemented between Vim and Neovim. Therefore, we use `noautocmd` to prevent triggering `WinEnter` and `WinLeave` events in Vim.

https://github.com/lambdalisue/fern.vim/issues/492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved cursor handling in the editor to prevent unintended side effects when switching windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->